### PR TITLE
So 1.16 doesn't works, but 1.16.x does

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,6 +18,6 @@
   "depends": {
     "fabricloader": ">=0.9.1",
     "fabric": "*",
-    "minecraft": "1.16"
+    "minecraft": "1.16.x"
   }
 }


### PR DESCRIPTION
This is concerning, but as long as it works